### PR TITLE
feat/linkfoot: allow no title in linkfoot

### DIFF
--- a/src/component/Dialog/VersionDialog.js
+++ b/src/component/Dialog/VersionDialog.js
@@ -39,25 +39,25 @@ class VersionDialog extends Component {
     w.location.href = "https://preview.mdnice.com/articles/";
   };
 
-  componentDidMount = async () => {
-    try {
-      const {
-        data: response,
-        data: {data},
-      } = await axios.get("https://api.mdnice.com/versions/newest");
-      if (!response.success) {
-        throw new Error();
-      }
-      const newestVersion = localStorage.getItem(NEWEST_VERSION);
-      if (data.versionNumber !== newestVersion) {
-        this.props.dialog.setVersionOpen(true);
-        localStorage.setItem(NEWEST_VERSION, data.versionNumber);
-      }
-      this.setState({...data});
-    } catch (err) {
-      console.error("读取最新Mdnice版本信息错误");
-    }
-  };
+  // componentDidMount = async () => {
+  //   try {
+  //     const {
+  //       data: response,
+  //       data: {data},
+  //     } = await axios.get("https://api.mdnice.com/versions/newest");
+  //     if (!response.success) {
+  //       throw new Error();
+  //     }
+  //     const newestVersion = localStorage.getItem(NEWEST_VERSION);
+  //     if (data.versionNumber !== newestVersion) {
+  //       this.props.dialog.setVersionOpen(true);
+  //       localStorage.setItem(NEWEST_VERSION, data.versionNumber);
+  //     }
+  //     this.setState({...data});
+  //   } catch (err) {
+  //     console.error("读取最新Mdnice版本信息错误");
+  //   }
+  // };
 
   render() {
     return (

--- a/src/utils/markdown-it-linkfoot.js
+++ b/src/utils/markdown-it-linkfoot.js
@@ -164,7 +164,7 @@ function linkFoot(state, silent) {
         }
       }
     } else {
-      title = "";
+      title = "NO_TITLE";
     }
 
     if (pos >= max || state.src.charCodeAt(pos) !== 0x29 /* ) */) {
@@ -215,7 +215,7 @@ function linkFoot(state, silent) {
   //
   if (!silent) {
     // 如果存在标题则转成脚注
-    if (title) {
+    if (title !== "NO_TITLE") {
       state.pos = labelStart;
       state.posMax = labelEnd;
 
@@ -231,7 +231,12 @@ function linkFoot(state, silent) {
       const footnoteId = state.env.footnotes.list.length;
 
       // *用来让链接倾斜
-      state.md.inline.parse(`${title}: *${footnoteContent}*`, state.md, state.env, (tokens = []));
+      state.md.inline.parse(
+        title ? `${title}: *${footnoteContent}*` : `${footnoteContent}`,
+        state.md,
+        state.env,
+        (tokens = []),
+      );
 
       token = state.push("footnote_word", "", 0);
       token.content = state.src.slice(labelStart, labelEnd);

--- a/src/utils/markdown-it-linkfoot.js
+++ b/src/utils/markdown-it-linkfoot.js
@@ -232,7 +232,7 @@ function linkFoot(state, silent) {
 
       // *用来让链接倾斜
       state.md.inline.parse(
-        title ? `${title}: *${footnoteContent}*` : `${footnoteContent}`,
+        title ? `${title}: *${footnoteContent}*` : `*${footnoteContent}*`,
         state.md,
         state.env,
         (tokens = []),


### PR DESCRIPTION
use `[title]([www.example.com](http://www.example.com/) "")` to add a link at the bottom with no link title:

```markdown
[1] www.example.com
```

<img width="636" alt="image" src="https://github.com/hust-open-atom-club/markdown-nice-build/assets/72600955/bfa23b3b-7b30-48c8-a135-ffd398c3dd27">
