### PR TITLE
feat: use bold in footlink title

### DIFF
--- a/src/utils/markdown-it-linkfoot.js
+++ b/src/utils/markdown-it-linkfoot.js
@@ -230,9 +230,9 @@ function linkFoot(state, silent) {
 
       const footnoteId = state.env.footnotes.list.length;
 
-      // *用来让链接倾斜
+      // *用来让链接倾斜，**用来让链接加粗
       state.md.inline.parse(
-        title ? `${title}: *${footnoteContent}*` : `*${footnoteContent}*`,
+        title ? `**${title}**: *${footnoteContent}*` : `*${footnoteContent}*`,
         state.md,
         state.env,
         (tokens = []),


### PR DESCRIPTION
- 为脚注中的链接标题格式加粗。